### PR TITLE
Remove .Site deprecations

### DIFF
--- a/layouts/partials/open-graph.html
+++ b/layouts/partials/open-graph.html
@@ -32,12 +32,12 @@
   {{ end }}
 {{ end }}{{ end }}
 {{ if .IsPage }}
-{{ range .Site.Authors }}{{ with .Social.facebook }}
-<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ with .Site.Social.facebook }}
+{{ range .Site.Params.Authors }}{{ with .Social.facebook }}
+<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}{{ with .Site.Params.Social.facebook }}
 <meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 <meta property="article:section" content="{{ .Section }}" />
 {{ with .Params.tags }}{{ range first 6 . }}
   <meta property="article:tag" content="{{ . }}" />{{ end }}{{ end }}
 {{ end }}{{ end }}
 <!-- Facebook Page Admin ID for Domain Insights -->
-{{ with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{ with .Site.Params.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}


### PR DESCRIPTION
.Site.Social and .Site.Authors have been deprecated. Change these references to the more generic .Site.Params versions in the OpenGraph template in order to avoid Hugo errors.